### PR TITLE
fix integration test warehouse envar

### DIFF
--- a/.github/workflows/dbt_integration_test.yml
+++ b/.github/workflows/dbt_integration_test.yml
@@ -3,8 +3,16 @@ run-name: ${{ github.event.inputs.branch }}
 
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
 
 concurrency: ${{ github.workflow }}
+
+env:
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
 
 jobs:
   called_workflow_template:
@@ -12,6 +20,6 @@ jobs:
     with:
       command: >
         dbt test --selector 'integration_tests'
-      environment:  ${{ github.ref == 'refs/heads/main' && 'workflow_prod' || 'workflow_dev' }}
+      environment:  ${{ inputs.environment }}
       warehouse: ${{ vars.WAREHOUSE }}
     secrets: inherit

--- a/.github/workflows/dbt_integration_test.yml
+++ b/.github/workflows/dbt_integration_test.yml
@@ -3,7 +3,6 @@ run-name: ${{ github.event.inputs.branch }}
 
 on:
   workflow_dispatch:
-  workflow_call:
     inputs:
       environment:
         required: true
@@ -11,15 +10,25 @@ on:
 
 concurrency: ${{ github.workflow }}
 
-env:
-  WAREHOUSE: "${{ vars.WAREHOUSE }}"
-
 jobs:
+  prepare_vars:
+    runs-on: ubuntu-latest
+    environment: 
+      name: ${{ inputs.environment }}  
+    outputs:  
+      warehouse: ${{ steps.set_outputs.outputs.warehouse }}
+    steps:
+      - name: Set warehouse output
+        id: set_outputs
+        run: |
+          echo "warehouse=${{ vars.WAREHOUSE }}" >> $GITHUB_OUTPUT  
+
   called_workflow_template:
+    needs: prepare_vars
     uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt.yml@main
     with:
       command: >
         dbt test --selector 'integration_tests'
-      environment:  ${{ inputs.environment }}
-      warehouse: ${{ vars.WAREHOUSE }}
+      environment: ${{ inputs.environment }}
+      warehouse: ${{ needs.prepare_vars.outputs.warehouse }}  
     secrets: inherit


### PR DESCRIPTION
- Adds `prepare_vars` step to set environment based `vars.warehosue` in steps output due to [limitations](https://docs.github.com/en/enterprise-cloud@latest/actions/sharing-automations/reusing-workflows#limitations) for using environment context in reusable workflows
